### PR TITLE
NPDOTF-470 (redo) Password encryption per RFC 5469

### DIFF
--- a/ts_cert.c
+++ b/ts_cert.c
@@ -51,8 +51,7 @@ TsStatus_t _ts_scep_create( TsScepConfigRef_t, int);
 static TsStatus_t _ts_handle_get( TsMessageRef_t fields );
 static TsStatus_t _ts_handle_set( TsScepConfigRef_t scepconfig, TsMessageRef_t fields );
 static TsStatus_t _ts_set_log( TsLogConfigRef_t log );
-static TsStatus_t  _ts_password_encrpyt(char* passwdPt, uint32_t PtLen, char* passwordCt);
-static TsStatus_t  _ts_password_decrypt(char* passCt, uint32_t CtLen, char* passwordPt);
+
 
 #if 1
 static TsStatus_t _log_scep( TsLogLevel_t level, char *message );
@@ -463,6 +462,107 @@ static TsStatus_t _ts_handle_set( TsScepConfigRef_t scepconfig, TsMessageRef_t f
 	return TsStatusOk;
 }
 
+// See what interface this comes up with
+ TsStatus_t getMAC(char* mac) {
+	 TsStatus_t iret = TsStatusOk;
+
+	 struct ifreq ifr;
+	 struct ifconf ifc;
+	 char buf[1024];
+	 int success = 0;
+
+	 int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+	 if (sock == -1) {
+		 return TsStatusError; // fix this
+	 };
+
+	 ifc.ifc_len = sizeof(buf);
+	 ifc.ifc_buf = buf;
+	 if (ioctl(sock, SIOCGIFCONF, &ifc) == -1) {
+		 return TsStatusError; // fix this
+	 }
+
+	 struct ifreq* it = ifc.ifc_req;
+	 const struct ifreq* const end = it + (ifc.ifc_len / sizeof(struct ifreq));
+
+	 for (; it != end; ++it) {
+		 strcpy(ifr.ifr_name, it->ifr_name);
+		 if (ioctl(sock, SIOCGIFFLAGS, &ifr) == 0) {
+			 if (! (ifr.ifr_flags & IFF_LOOPBACK)) { // don't count loopback
+				 if (ioctl(sock, SIOCGIFHWADDR, &ifr) == 0) {
+					 success = 1;
+					 break;
+				 }
+			 }
+		 }
+		 else {
+			 return TsStatusError; // fix this
+		 }
+	 }
+
+
+	 if (success) memcpy(mac, ifr.ifr_hwaddr.sa_data, 6);
+	 return iret;
+ }
+
+
+// Get cpu serial number 64 bit from Ras Pi cpu
+ TsStatus_t getSerial(uint64_t* serial)
+{
+
+ 	TsStatus_t iret = TsStatusOk;
+
+
+   FILE *filp;
+   char buf[512];
+   char term;
+
+   filp = fopen ("/proc/cpuinfo", "r");
+
+   if (filp != NULL)
+   {
+      while (fgets(buf, sizeof(buf), filp) != NULL)
+      {
+         if (!strncasecmp("serial\t\t:", buf, 9))
+         {
+            sscanf(buf+9, "%Lx", serial);
+         }
+      }
+
+      fclose(filp);
+   }
+    else
+   	iret = TsStatusError;
+
+   return iret;
+}
+
+static TsStatus_t makeKey256(uint8_t* key256)
+{
+	 hwAccelDescr    hwAccelCtx;
+	 ubyte*          pRetData = NULL;
+	 TsStatus_t  iret = TsStatusOk;
+	 uint8_t mac[6];
+	 uint64_t serial;
+
+	 // Form a 256 bit key from the MAC address and the RaspPi serial number
+	 iret = getMAC(&mac[0]);
+	 if (iret!=TsStatusOk)
+		 goto error;
+
+	 iret = getSerial(&serial);
+	 if (iret!=TsStatusOk)
+		 goto error;
+
+	 // Create the key
+	 memset(key256,0,32);
+	 memcpy(key256, &mac[0],6); // 48 bits
+	 memcpy(key256+6, &serial, 8); // 64 bits 112 bits
+	error:
+	return iret;
+
+}
+
 /**
  * Save a scep configuration object to a file
 
@@ -473,7 +573,7 @@ TsStatus_t ts_scepconfig_save( TsScepConfig_t* pConfig, char* path, char* filena
  	ts_file_handle handle;
  	uint32_t actual_size, size;
  	uint8_t* addr;
- 	char text_line[120];
+ 	char text_line[600];
 
 	ts_status_debug("ts_scepconfig_save: save the scepconfig structure\n");
 
@@ -607,6 +707,7 @@ TsStatus_t ts_scepconfig_save( TsScepConfig_t* pConfig, char* path, char* filena
 			ts_status_debug("ts_scepconfig_save: Error in writing challengeUsername to file\n");
 	 		goto error;
 		}
+	 	// Password (Shared secret)
 #define KEYWRAP
 #ifdef NO_ENCRYPTION
 	 	snprintf(text_line, sizeof(text_line), "%s\n",pConfig->_challengePassword);
@@ -630,14 +731,25 @@ TsStatus_t ts_scepconfig_save( TsScepConfig_t* pConfig, char* path, char* filena
 #endif
 #ifdef KEYWRAP
 	 	// Encrypt the password aes256 ECB per the keywrap RFC
-	 	char passwordCt[100]; // 8 longer than input is mandatory for IV
-        char toAscii[200];
+	 	char passwordCt[256]; // 8 longer than input is mandatory for IV
+        char toAscii[500];
+        uint8_t aes256key[32];
+        uint32_t sizeCt = 0;
 
-        // Encrypt the password - the outout CT is 8 longer than the input
-        iret = _ts_password_encrpyt(pConfig->_challengePassword, strlen(pConfig->_challengePassword), passwordCt);
+        // Create the AES 256 bit key (32 bytes)
+        iret = makeKey256(&aes256key[0]);
+	 	if (iret!=TsStatusOk) {
+			ts_status_debug("ts_scepconfig: Bad keygen during save encrypt\n");
+	 		goto error;
+		}
+
+	 	// Wrap the key in RFC 5649 mode to handle buffers not multiple of 8
+	 	 MSTATUS ret = AESKWRAP_encrypt5649( MOC_SYM(hwAccelCtx) &aes256key[0],
+	 				 256/8 , &pConfig->_challengePassword[0],  strlen(pConfig->_challengePassword),
+	 				 passwordCt, sizeof(passwordCt), &sizeCt);
 
         // Now convert the password binary to text (ie 0x0CFACE3D becomes "0CFACE2D")
-        X2A(passwordCt, toAscii, strlen(pConfig->_challengePassword)+8);  // CT is 8 longer; outut ascii must git 2*(origin pw len+8)
+        X2A(passwordCt, toAscii, sizeof(passwordCt));  // CT up to 15 longer than PT, and this will be 2* origig
 	 	snprintf(text_line, sizeof(text_line), "%s\n", toAscii);
 	 	iret = 	ts_file_writeline(&handle,text_line);
 	 	if (iret!=TsStatusOk) {
@@ -645,7 +757,7 @@ TsStatus_t ts_scepconfig_save( TsScepConfig_t* pConfig, char* path, char* filena
 	 		goto error;
 		}
 #endif
-
+	 	// Fingerprint
 	 	snprintf(text_line, sizeof(text_line), "%s\n",pConfig->_caCertFingerprint);
 	 	iret = 	 	ts_file_writeline(&handle,text_line);
 	 	if (iret!=TsStatusOk) {
@@ -698,7 +810,7 @@ TsStatus_t ts_scepconfig_save( TsScepConfig_t* pConfig, char* path, char* filena
 	 	ts_file_handle handle;
 	 	uint32_t actual_size, size;
 	 	uint8_t* addr;
-	 	char text_line[120];
+	 	char text_line[256];
 	 	// These are all used to whold string in the passed struct ptr - the are returned via ptr so need statics
 		static char bfr_certExpiresAfter[30];
 		static char bfr_certEnrollmentType[30];
@@ -870,19 +982,36 @@ TsStatus_t ts_scepconfig_save( TsScepConfig_t* pConfig, char* path, char* filena
 #endif
 #ifdef KEYWRAP
 	 	// Encrypt the password aes256 ECB per the keywrap RFC
-        char toHex[200];
-        char passwordPt[200];
+
+        char toHex[128];
+	 	char passwordPt[256]; // 8 longer than input is mandatory for IV
+        char toAscii[500];
+        uint8_t aes256key[32];
+        uint32_t ptLength;
 
 	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
 	 	if (TsStatusOk != iret)
 	 		goto error;
-        // Take the CT ascii password and convert it to binary CT for to prep for decryption
-        A2X(text_line, toHex, strlen(text_line));  // new lenght in binary should be 1/2 original string
-        iret = _ts_password_decrypt(toHex strlen(pConfig->_challengePassword)/2, passwordPt);  // decrupt len is origin len -8
-        // Now convert the password binary to text (ie 0x0CFACE3D becomes "0CFACE2D")
 
+        // Take the CT ascii password and convert it to binary CT for to prep for decryption
+	 	A2X(text_line, toHex, strlen(text_line));  // new lenght in binary should be 1/2 original string
+        int ctLen = strlen(text_line)/2;
+
+        // Create the AES 256 bit key (32 bytes)
+        iret = makeKey256(&aes256key[0]);
+	 	if (iret!=TsStatusOk) {
+			ts_status_debug("ts_scepconfig: Bad keygen during save encrypt\n");
+	 		goto error;
+		}
+
+	 	// Wrap the key in RFC 5649 mode to handle buffers not multiple of 8
+	 	MSTATUS ret = AESKWRAP_decrypt5649( MOC_SYM(hwAccelCtx) &aes256key[0],
+	 			256/8, toHex, ctLen, &passwordPt[0], sizeof(passwordPt), &ptLength);
+        passwordPt[ptLength]='\0'; // end the buffer as a string
+
+        // Save the decrypted password
 	 	pConfig->_challengePassword = bfr_challengePassword;
-	 	strncpy(bfr_challengePassword, passwordPt, (strlen(pConfig->_challengePassword)/2)-8);
+	 	strncpy(bfr_challengePassword, passwordPt, strlen(passwordPt));
 #endif
 	 	//
 
@@ -969,242 +1098,7 @@ bool ts_check_opcert_available()
 	return true;
 }
 
- // See what interface this comes up with
- TsStatus_t getMAC(char* mac) {
-	 TsStatus_t iret = TsStatusOk;
 
-	 struct ifreq ifr;
-	 struct ifconf ifc;
-	 char buf[1024];
-	 int success = 0;
-
-	 int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
-	 if (sock == -1) {
-		 return TsStatusError; // fix this
-	 };
-
-	 ifc.ifc_len = sizeof(buf);
-	 ifc.ifc_buf = buf;
-	 if (ioctl(sock, SIOCGIFCONF, &ifc) == -1) {
-		 return TsStatusError; // fix this
-	 }
-
-	 struct ifreq* it = ifc.ifc_req;
-	 const struct ifreq* const end = it + (ifc.ifc_len / sizeof(struct ifreq));
-
-	 for (; it != end; ++it) {
-		 strcpy(ifr.ifr_name, it->ifr_name);
-		 if (ioctl(sock, SIOCGIFFLAGS, &ifr) == 0) {
-			 if (! (ifr.ifr_flags & IFF_LOOPBACK)) { // don't count loopback
-				 if (ioctl(sock, SIOCGIFHWADDR, &ifr) == 0) {
-					 success = 1;
-					 break;
-				 }
-			 }
-		 }
-		 else {
-			 return TsStatusError; // fix this
-		 }
-	 }
-
-
-	 if (success) memcpy(mac, ifr.ifr_hwaddr.sa_data, 6);
-	 return iret;
- }
-
- // Get cpu serial number 64 bit from Ras Pi cpu
- uint64_t getSerial(void)
- {
-    static uint64_t serial = 0;
-
-    FILE *filp;
-    char buf[512];
-    char term;
-
-    filp = fopen ("/proc/cpuinfo", "r");
-
-    if (filp != NULL)
-    {
-       while (fgets(buf, sizeof(buf), filp) != NULL)
-       {
-          if (!strncasecmp("serial\t\t:", buf, 9))
-          {
-             sscanf(buf+9, "%Lx", &serial);
-          }
-       }
-
-       fclose(filp);
-    }
-    return serial;
- }
-
- static TsStatus_t  _ts_password_encrpyt(char* passwdPt, uint32_t PtLen, char* passwordCt)
- {
-
-	 hwAccelDescr    hwAccelCtx;
-	 ubyte*          pRetData = NULL;
-	 TsStatus_t  iret = TsStatusOk;
-	 uint8_t key256[32];  //256 bit key
-	 uint8_t mac[6];
-
-	 // Form a 256 bit key from the MAC address and the RaspPi serial number
-	 iret = getMAC(&mac[0]);
-	 uint64_t serial = getSerial();
-
-	 memset(&key256[0],0,sizeof(key256));
-	 memcpy(&key256[0], &mac[0],6); // 48 bits
-	 memcpy(&key256[6], &serial, 8); // 64 bits 112 bits
-
-	 // rfc 5649
-	 MSTATUS ret = AESKWRAP_encrypt( MOC_SYM(hwAccelCtx) ubyte* &key256[0],
-			 256/8 , passwdPt,  PtLen,
-			 passwordCt); /* SHould be dataLen + 8 */
-#if 0
-     ///
-     extern MSTATUS
-     AESKWRAP_encrypt( MOC_SYM(hwAccelDescr hwAccelCtx) ubyte* keyMaterial,
-                      sbyte4 keyLength, const ubyte* data, ubyte4 dataLen,
-                      ubyte * retData/* SHould be dataLen + 8 */)
-     {
-
-         if (OK > (status = AESKWRAP_encrypt(MOC_SYM(hwAccelCtx) kek,(sbyte4)EAPOL_KEK_SIZE,
-                      pPkt, pktLen, pRetData)))
-             goto exit;
-
-         MOC_MEMCPY(pPkt, pRetData, pktLen + 8);
-     }
-#endif
-	 if (ret != OK)
-		 iret = TsStatusError;
-
-	 return iret;
- }
-
- static TsStatus_t  _ts_password_decrypt(char* passCt, uint32 CtLen, char* passwordPt)
- {
-
-	 hwAccelDescr    hwAccelCtx;
-	 TsStatus_t      iret = TsStatusOk;
-	 uint8_t key256[32];  //256 bit key
-	 uint8_t mac[6];
-	 TsStatus_t iret = TsStatusOk;
-
-	 // Form a 256 bit key from the MAC address and the RaspPi serial number
-	 iret = getMAC(&mac[0]);
-
-	 uint64_t serial = getSerial();
-
-	 memset(&key256[0],0,sizeof(key256));
-	 memcpy(&key256[0], &mac[0],6); // 48 bits
-	 memcpy(&key256[6], &serial, 8); // 64 bits 112 bits
-
-#if 0
-	 // rfc 5649
-	 MSTATUS iret = AESKWRAP_encrypt( MOC_SYM(hwAccelCtx) &key256[0],
-			 256/8 , passwdPt,  PtLen,
-			 *passwordCt); /* SHould be dataLen + 8 */
-
-
-     {
-         if (OK > (status = AESKWRAP_decrypt(MOC_SYM(hwAccelCtx) kek,(sbyte4)EAPOL_KEK_SIZE,
-                      pPkt, pktLen, pRetData)))
-             goto exit;
-#endif
-	 MSTATUS ret  =
-	 AESKWRAP_decrypt(MOC_SYM(hwAccelDescr hwAccelCtx) &key256[0], 256/8,
-	                  passCt, CtLen,
-	                  *passwordPt);  /* retun data -8 len */
-
-	 if (ret == what)
-		 iret = TsStatusFail;
-
-	 return iret;
-
-
- }
-
-
-
-/// example
-#if 0
- extern MSTATUS
- AESKWRAP_decrypt(MOC_SYM(hwAccelDescr hwAccelCtx) ubyte* keyMaterial,
-                  sbyte4 keyLength, const ubyte* data, ubyte4 dataLen,
-                  ubyte * retData /* datalen - 8 */ )
- {
-     MSTATUS status;
-
-     ///
-     extern MSTATUS
-     AESKWRAP_encrypt( MOC_SYM(hwAccelDescr hwAccelCtx) ubyte* keyMaterial,
-                      sbyte4 keyLength, const ubyte* data, ubyte4 dataLen,
-                      ubyte * retData/* SHould be dataLen + 8 */)
-     {
-       return AESKWRAP_encryptAux (
-         MOC_SYM(hwAccelCtx) MOC_AES_WRAP_OLD_CODE, keyMaterial, keyLength,
-         data, dataLen, 0, kIV3394, retData);
-     }
-
- // fragments mocana
-
- {
-     if (OK > (status = AESKWRAP_encrypt(MOC_SYM(hwAccelCtx) kek,(sbyte4)EAPOL_KEK_SIZE,
-                  pPkt, pktLen, pRetData)))
-         goto exit;
-
-     MOC_MEMCPY(pPkt, pRetData, pktLen + 8);
-
-
-     static MSTATUS
-     EAPOL_PTK_encryptDecryptAES(eapolKeyFrame *keyFrame, ubyte* kek, ubyte *pPkt, sbyte4 pktLen, ubyte encryptFlag)
-     {
-         hwAccelDescr    hwAccelCtx;
-         ubyte*          pRetData = NULL;
-         MSTATUS         status = OK;
-
-         if (!keyFrame || !kek)
-         {
-             status = ERR_NULL_POINTER;
-             goto exit;
-         }
-
-         if (OK > (status = (MSTATUS)HARDWARE_ACCEL_OPEN_CHANNEL(MOCANA_EAP, &hwAccelCtx)))
-             goto exit;
-
-         if (NULL == (pRetData = MALLOC(pktLen + 8)))
-         {
-             status = ERR_MEM_ALLOC_FAIL;
-             goto exit;
-         }
-
-         if (0 == encryptFlag)
-         {
-             if (OK > (status = AESKWRAP_decrypt(MOC_SYM(hwAccelCtx) kek,(sbyte4)EAPOL_KEK_SIZE,
-                          pPkt, pktLen, pRetData)))
-                 goto exit;
-
-             MOC_MEMCPY(pPkt, pRetData, pktLen);
-         }
-         else if (1 == encryptFlag)
-         {
-             if (OK > (status = AESKWRAP_encrypt(MOC_SYM(hwAccelCtx) kek,(sbyte4)EAPOL_KEK_SIZE,
-                          pPkt, pktLen, pRetData)))
-                 goto exit;
-
-             MOC_MEMCPY(pPkt, pRetData, pktLen + 8);
-         }
-
-     exit:
-         HARDWARE_ACCEL_CLOSE_CHANNEL(MOCANA_EAP, &hwAccelCtx);
-         if (pRetData)
-         {
-             FREE(pRetData);
-         }
-
-         return status;
-     }
-
-#endif
 int A2X(char* ascii, char* hex, int len)
 {
 	int i;
@@ -1232,4 +1126,226 @@ int X2A(char* hex,  char* ascii, int len)
     return 0;
 }
 
+// Test code generator - future FIPS140-2 use
+TsStatus_t ts_scepconfig_setup(TsScepConfig_t* pConfig, char* path, char* filename)
+  {
+	 	TsStatus_t iret = TsStatusOk;
+	 	ts_file_handle handle;
+	 	uint32_t actual_size, size;
+	 	uint8_t* addr;
+	 	char text_line[120];
+	 	// These are all used to whold string in the passed struct ptr - the are returned via ptr so need statics
+		static char bfr_certExpiresAfter[30];
+		static char bfr_certEnrollmentType[30];
+	 	static char bfr_encryptionAlgorithm[100];
+	 	static char bfr_hashFunction[16];
+	 	static char bfr_keyUsage[30];
+	 	static char bfr_keyAlgorithm[100];
+	 	static char bfr_keyAlgorithmStrength[10];
+	 	static char bfr_urlBuffer[100];
+	 	static char bfr_challengeUsername[30];
+		static char bfr_challengePassword[30];
+		static char bfr_caCertFingerprint[100];
+		static char bfr_certSubject[100];
+		static char bfr_getCaCertUrl[100];
+
+
+	 	// Set the default directory, then open and size the file. Malloc some ram and read it all it.
+
+	 	iret = ts_file_directory_default_set(path);
+	 	if (TsStatusOk != iret)
+	 		goto error;
+
+	 	// Open the specific config file in the given directory
+	 	iret =  ts_file_open(&handle, filename, TS_FILE_OPEN_FOR_READ);
+	 	if (TsStatusOk != iret)
+	 		goto error;
+
+
+	   // Read each line in the config, storing the data, but first verify the format written is compatible with this
+	   // version of the code
+
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+
+	 	// Go the REV = check it - error if no match
+	 	if (strcmp(text_line,SCEP_CONFIG_REV ) !=0)
+	 	{
+	 		iret = TsStatusErrorMediaInvalid;
+	 		goto error;
+
+	 	}
+
+	 	// Auto Renew
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_enabled = (strcmp(text_line,"1")==0)?true:false;
+
+	 	// Generate private key
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_generateNewPrivateKey = (strcmp(text_line,"1")==0)?true:false;
+
+	 	// _certExpiresAfter
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_certExpiresAfter = bfr_certExpiresAfter;
+	 	strncpy(bfr_certExpiresAfter, text_line,sizeof(bfr_certExpiresAfter));
+
+	    // _certEnrollmentType
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_certEnrollmentType = bfr_certEnrollmentType;
+	 	strncpy(bfr_certEnrollmentType, text_line,sizeof(bfr_certEnrollmentType));
+
+        // _numDaysBeforeAutoRenew
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	    sscanf( text_line, "%d", &(pConfig->_numDaysBeforeAutoRenew));
+
+	    // _encryptionAlgorithm
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_encryptionAlgorithm = bfr_encryptionAlgorithm;
+	 	strncpy(bfr_encryptionAlgorithm, text_line,sizeof(bfr_encryptionAlgorithm));
+
+	 	// _hashFunction
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_hashFunction = bfr_hashFunction;
+	 	strncpy(bfr_hashFunction, text_line,sizeof(bfr_hashFunction));
+
+
+	 	// _retries
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	    sscanf( text_line, "%d", &(pConfig->_retries));
+
+	    // _retryDelayInSeconds
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	    sscanf( text_line, "%d", &(pConfig->_retryDelayInSeconds));
+
+	    // _keySize
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	    sscanf( text_line, "%d", &(pConfig->_keySize));
+
+	    // _keyUsage
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_keyUsage= bfr_keyUsage;
+	 	strncpy(bfr_keyUsage, text_line,sizeof(bfr_keyUsage));
+
+	 	// _keyAlgorithm
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_keyAlgorithm = bfr_keyAlgorithm;
+	 	strncpy(bfr_keyAlgorithm, text_line,sizeof(bfr_keyAlgorithm));
+
+	 	// _keyAlgorithmStrength
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_keyAlgorithmStrength = bfr_keyAlgorithmStrength;
+	 	strncpy(bfr_keyAlgorithmStrength, text_line,sizeof(bfr_keyAlgorithmStrength));
+
+	 	// _caInstance
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	    sscanf( text_line, "%d", &(pConfig->_caInstance));
+
+	 	// _challengeType
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	    sscanf( text_line, "%d", &(pConfig->_challengeType));
+
+	    // _challengeUsername
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_challengeUsername = bfr_challengeUsername;
+	 	strncpy(bfr_challengeUsername, text_line,sizeof(bfr_challengeUsername));
+
+#define XXX
+#ifdef XXX
+	 	// _challengePassword
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_challengePassword = bfr_challengePassword;
+	 	strncpy(bfr_challengePassword, text_line,sizeof(bfr_challengePassword));
+#endif
+#ifdef LIGHT_ENCRYPTION
+        char toHex[200];
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+        A2X(text_line, toHex, strlen(text_line));
+        toHex[strlen(text_line)/2]='\0';
+	 	pConfig->_challengePassword = bfr_challengePassword;
+	 	strncpy(bfr_challengePassword, toHex, strlen(toHex));
+
+
+#endif
+
+	 	//
+
+
+	 	// _caCertFingerprint
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_caCertFingerprint = bfr_caCertFingerprint;
+	 	strncpy(bfr_caCertFingerprint, text_line,sizeof(bfr_caCertFingerprint));
+
+
+	 	// _certSubject
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_certSubject = bfr_certSubject;
+	 	strncpy(bfr_certSubject, text_line,sizeof(bfr_certSubject));
+
+
+	 	// _getCaCertUrl
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	 	pConfig->_getCaCertUrl = bfr_getCaCertUrl;
+	 	strncpy(bfr_getCaCertUrl, text_line,sizeof(bfr_getCaCertUrl));
+
+	    // _getPkcsRequestUrl
+	    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+	 	if (TsStatusOk != iret)
+	 		goto error;
+	    sscanf( text_line, "%d", &(pConfig->_getPkcsRequestUrl));
+
+	    // _getCertInitialUrl
+		    iret = ts_file_readline(&handle, text_line, sizeof(text_line));
+		 	if (TsStatusOk != iret)
+		 		goto error;
+		    sscanf( text_line, "%d", &(pConfig->_getCertInitialUrl));
+
+	 	error:
+	 	ts_file_close(&handle);
+
+	 	return iret;
+
+  }
 


### PR DESCRIPTION
Update the scepconfig rev info for the new password encryption scheme. Scepconfig will get replaced the next time scep params are sent to the board and will be encrypted with the strong alg, replacing the weak alg used in the original release.

Remove the NO and WEAK encryption code as well.